### PR TITLE
Allow user to specify first automatically generated SC ID

### DIFF
--- a/sc/sc.py
+++ b/sc/sc.py
@@ -12,8 +12,8 @@ sndpath = os.path.join( os.getcwd() , 'sounds' )
 synthdefpath = os.path.join( os.getcwd() , 'synthdefs' )
 
 
-def start( exedir='', port=57110, inputs=2, outputs=2, samplerate=44100, verbose=0,
-           spew=0, startscsynth=0 ) :
+def start( exedir='', port=57110, inputs=21, outputs=2, samplerate=44100, verbose=0,
+           spew=0, startscsynth=0, firstAutoID=1000) :
     """ starts scsynth process. interfaces scsynth module.
     Inits the OSC communication and classes that handle it
     exe='', exedir='', port=57110, inputs=2, outputs=2, samplerate=44100, verbose=0, spew=0
@@ -43,6 +43,7 @@ def start( exedir='', port=57110, inputs=2, outputs=2, samplerate=44100, verbose
                 #samplerate = samplerate,
                 verbose = verbose,
                 spew = spew,
+                firstAutoID=firstAutoID
                 )
     
     if startscsynth : # starts scsynth server process

--- a/scsynth/server.py
+++ b/scsynth/server.py
@@ -36,11 +36,11 @@ class _Server(scosc.Controller):
     
     proc = None
 
-    def __init__(self, addr, verbose=False):
+    def __init__(self, addr, verbose=False, firstAutoID=1000):
         scosc.Controller.__init__(self, addr, verbose)
         self.audiobuspool = pool.IntPool(29)
         self.controlbuspool = pool.IntPool(0)
-        self.synthpool = pool.IntPool(1000) 
+        self.synthpool = pool.IntPool(firstAutoID) 
         self.bufferpool = pool.IntPool(0)
         
     def quit(self):
@@ -56,9 +56,9 @@ class _Server(scosc.Controller):
             self.kill()
 
 
-def connect(iphost='localhost', port=57110, verbose=False, spew=False):
+def connect(iphost='localhost', port=57110, verbose=False, spew=False, firstAutoID=1000):
     ip = socket.gethostbyname(iphost)
-    s = _Server((ip, port), verbose)
+    s = _Server((ip, port), verbose, firstAutoID)
     s.spew = spew
     #s.sendMsg('/status', 1)
     #s.receive('status.reply')
@@ -68,7 +68,7 @@ def connect(iphost='localhost', port=57110, verbose=False, spew=False):
 def start( #exe = 'scsynth', exedir = '/Applications/SuperCollider',
           port = 57110,
           #inputs = 2, outputs = 2, samplerate = 48000,
-          verbose = False, spew = False,
+          verbose = False, spew = False, firstAutoID=1000
           ) :
 ##    instance = process.start_local(exe, exedir, port,
 ##                                   inputs, outputs, samplerate, 
@@ -76,7 +76,7 @@ def start( #exe = 'scsynth', exedir = '/Applications/SuperCollider',
 ##                                    )
     import time
     time.sleep(1)
-    s = connect('127.0.0.1', port, verbose=verbose, spew=spew)
+    s = connect('127.0.0.1', port, verbose=verbose, spew=spew, firstAutoID=firstAutoID)
 ##    s.instance = 0 # instance
     return s
 


### PR DESCRIPTION
Currently, node IDs are always generated starting with 1001.  This can lead to conflicts if nodes are created by separate programs.

This pull request allows the user to specify the starting position for automatically generating IDs.
`sc.start(firstAutoID=1005)`